### PR TITLE
Bug fix: after loading a game with a FEN position, starting a game did not take the position into account

### DIFF
--- a/jcchess/load_save.py
+++ b/jcchess/load_save.py
@@ -164,7 +164,7 @@ class Load_Save:
 
         gv.jcchess.set_movelist(movelist)
         gv.jcchess.set_redolist(redolist)
-        gv.jcchess.set_startpos(startpos)
+        gv.jcchess.set_startpos(fen)
         gv.jcchess.set_lastmove(lastmove)
 
         gv.board.update()


### PR DESCRIPTION
The position was only changed on the board, but the engine was not able to process with the loaded position. Instead, it still thought it was from the start of the game.